### PR TITLE
Parallel javascript

### DIFF
--- a/JavaScript/.gitignore
+++ b/JavaScript/.gitignore
@@ -1,0 +1,1 @@
+/node_modules/

--- a/JavaScript/README.md
+++ b/JavaScript/README.md
@@ -1,0 +1,17 @@
+pi_sequential.js
+----------------
+
+
+
+pi_parallel_cluster.js
+----------------------
+
+Node.js 4 is required.
+
+Get easy install of Node 4 with [nvm](https://github.com/creationix/nvm), and `nvm use 4`.
+
+```
+nvm use 4
+npm install
+./pi_parallel_cluster.js
+```

--- a/JavaScript/output.js
+++ b/JavaScript/output.js
@@ -4,9 +4,16 @@
  *  Copyright © 2014  Russel Winder
  */
 
-function out(prefix, pi, n, elapseTime) {
+// For nodejs
+if (typeof print === 'undefined') var print = (msg) => {console.log(msg)};
+
+function out(prefix, π, n, elapseTime, workers) {
   print('==================== ' + prefix);
-  print('\tπ = ' + pi);
+  print('\tπ = ' + π);
   print('\titeration count = ' + n);
   print('\telapse time = ' + elapseTime);
+  print('\tworkers = ' + workers);
 }
+
+// For nodejs
+module.exports = out;

--- a/JavaScript/package.json
+++ b/JavaScript/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "pi",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/russel/Pi_Quadrature.git"
+  },
+  "dependencies": {
+    "asyncawait": "^1.0.0",
+    "bluebird": "^2.10.1"
+  },
+  "license": "GPL-3.0"
+}

--- a/JavaScript/pi_parallel_cluster.js
+++ b/JavaScript/pi_parallel_cluster.js
@@ -1,0 +1,74 @@
+#! /usr/bin/env node
+
+/*
+ *  Calculation of π using quadrature realized with a parallel algorithm in cluster.
+ *
+ *  This expects nodejs 4.
+ *
+ *  Copyright © 2015 Fredrik Liljegren
+ *
+ *  Interresting note: I started using `let` instead of `var` everywhere, but when using `let` in
+ *  the partialSum function, the calculation took very much longer to perform.  I guess the scoping
+ *  of the variable adds some extra overhead…
+ */
+
+'use strict';
+
+const cluster = require('cluster')
+const out     = require('./output.js')
+const Promise = require('bluebird')
+var async     = require('asyncawait/async')
+var await     = require('asyncawait/await')
+
+const partialSum = (id, sliceSize, ð) => {
+  const start = 1 + id * sliceSize
+  const end   = (id + 1) * sliceSize + 1
+  var   Σ     = 0
+
+  for (var i = start; i < end; i++) {
+    var x = (i - 0.5) * ð
+    Σ += 1 / (1 + x * x)
+  }
+  return Σ
+}
+
+const execute = async((tasks) => {
+  const n         = 1000000000
+  const ð         = 1.0 / n
+  const startTime = Date.now()
+  const sliceSize = n / tasks
+
+  const promises = []
+  for (var i = 0; i < tasks; i++) {
+    const worker = cluster.fork({id: i, sliceSize: sliceSize, ð: ð})
+
+    promises.push(new Promise((resolve, reject) => {
+      worker.on('message', (event) => {resolve(event)})
+    }))
+  }
+
+  // Wait for all workers
+  const Σ = await(Promise.all(promises).then((ðs) => ðs.reduce((Σ, ð) => Σ + ð, 0)))
+  const π = 4.0 * ð * Σ
+  const elapseTime = (Date.now() - startTime) / 1e3
+
+  out('pi_parallel_cluster', π, n, elapseTime, tasks)
+})
+
+if (cluster.isMaster) {
+  async(() => {
+    await(execute(1))
+    await(execute(2))
+    await(execute(8))
+    await(execute(32))
+  })().done()
+}
+else {
+  // This is a worker process, get slice from env and perform calculation.
+  const ð         = parseFloat(process.env.ð)
+  const id        = parseInt(process.env.id)
+  const sliceSize = parseFloat(process.env.sliceSize)
+
+  cluster.worker.send(partialSum(id, sliceSize, ð))
+  cluster.worker.kill()
+}

--- a/JavaScript/pi_sequential.js
+++ b/JavaScript/pi_sequential.js
@@ -6,16 +6,20 @@
  *  Copyright © 2014  Russel Winder
  */
 
-load('output.js')
+'use strict';
 
-var n = 100000000 // 10 times fewer.
-var delta = 1.0 / n
+const out = require('./output.js')
+
+var n = 1000000000
+var ð = 1.0 / n
 var startTime = Date.now()
-var sum = 0.0
+
+var Σ = 0.0
+
 for (var i = 0; i < n; ++i) {
-  var x = (i - 0.5) * delta
-  sum += 1.0 / (1.0 + x * x)
+  var x = (i - 0.5) * ð
+  Σ += 1.0 / (1.0 + x * x)
 }
-var pi = 4.0 * delta * sum
+var π = 4.0 * ð * Σ
 var elapseTime = (Date.now() - startTime) / 1e3
-out('pi_sequential', pi, n, elapseTime)
+out('pi_sequential', π, n, elapseTime, 1)


### PR DESCRIPTION
I added a parallel javascript version for Node.js 4, with fiber-based async/await and the builtin `cluster` module to make worker processes.

On my computer, the sequential takes about 3.9 s, the parallel:
 1 - 3.9 s
 2 - 2.0 s
 8 - 1.2 s
 32 - 1.7 s

I've been cruel and slightly modernized the sequential version as well.  I don't have jjs so I have no idea if it still works though, perhaps I should revert that.  I upped the `n` on the sequential version to match the other languages, since it was quite quick anyway (on a modern laptop).
